### PR TITLE
Add cross compile for 2.11 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,14 @@ name := "schale"
 
 version := "1.0"
 
-scalaVersion := "2.10.2"
+// http://www.scala-sbt.org/0.13/docs/Cross-Build.html#Cross-Building+a+Project
+crossScalaVersions := Seq("2.10.4", "2.11.7")
 
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.2.0"
+libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.3.12"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "1.9.1" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 
 jarName in assembly := "schale.jar"
 

--- a/src/test/scala/at/loveoneanother/schale/ProcTest.scala
+++ b/src/test/scala/at/loveoneanother/schale/ProcTest.scala
@@ -118,11 +118,15 @@ class ProcTest extends FunSuite {
         expectResult("a") { Shell("echo $newvar").toString }
         expectResult("/") { Command("pwd").toString }
       }
-      cd("/tmp") {
+
+      // MacOS redirects /tmp to /private/tmp as canonical path
+      val tmpPath = new java.io.File(System.getProperty("java.io.tmpdir")).getCanonicalPath
+      val tmpdir = tmpPath.toString
+      cd(tmpdir) {
         expectResult("a") { Shell("echo $newvar").toString }
-        expectResult("/tmp") { Command("pwd").toString }
+        expectResult(tmpdir) { Command("pwd").toString }
         env(Map("newvar2" -> "b")) {
-          expectResult("/tmp") { Command("pwd").toString }
+          expectResult(tmpdir) { Command("pwd").toString }
           cd("/") {
             expectResult("a") { Shell("echo $newvar").toString }
             expectResult("b") { Shell("echo $newvar2").toString }


### PR DESCRIPTION
Also update to latest Akka / Scalatest.
Fix a failing test due to Mac /tmp path redirecting to /private/tmp.
